### PR TITLE
Add xterm with Spinner type showing progress

### DIFF
--- a/xansi/escapecodes.go
+++ b/xansi/escapecodes.go
@@ -30,7 +30,15 @@ func (sgr *SGR) String() string {
 	return strings.Join(parts, ";")
 }
 
-const esc = "\u001b["
+const esc = "\u001b"
+
+var (
+	HideCursor             = esc + "[?25l"
+	ShowCursor             = esc + "[?25h"
+	ClearLineRightOfCursor = esc + "[0K"
+	ClearLineLeftOfCursor  = esc + "[1K"
+	ClearLineAtCursor      = esc + "[2K"
+)
 
 var (
 	AllReset  = SGR{attribute: 0}
@@ -147,5 +155,5 @@ func BgColor24(r, g, b int) SGR {
 
 // Reset resets any SGR.
 func Reset() string {
-	return esc + AllReset.String() + "m"
+	return esc + "[" + AllReset.String() + "m"
 }

--- a/xansi/style.go
+++ b/xansi/style.go
@@ -9,7 +9,7 @@ import (
 
 type Render []SGR
 
-func (s Render) Join() string {
+func (s Render) join() string {
 	if len(s) == 0 {
 		return ""
 	}
@@ -19,9 +19,9 @@ func (s Render) Join() string {
 		parts[i] = sgr.String()
 	}
 
-	return esc + strings.Join(parts, ";") + "m"
+	return strings.Join(parts, ";") + "m"
 }
 
 func (s Render) Sprintf(format string, a ...interface{}) string {
-	return s.Join() + fmt.Sprintf(format, a...)
+	return esc + "[" + s.join() + fmt.Sprintf(format, a...)
 }

--- a/xansi/style_test.go
+++ b/xansi/style_test.go
@@ -11,39 +11,39 @@ import (
 func TestRender_Sprintf(t *testing.T) {
 	t.Run("bold text", func(t *testing.T) {
 		res := Render{Bold}.Sprintf("I am Bold!")
-		xt.Eq(t, esc+"1mI am Bold!", res)
+		xt.Eq(t, esc+"[1mI am Bold!", res)
 	})
 
 	t.Run("bold text", func(t *testing.T) {
 		res := Render{Bold}.Sprintf("I am Bold!")
-		xt.Eq(t, esc+"1mI am Bold!", res)
+		xt.Eq(t, esc+"[1mI am Bold!", res)
 	})
 
 	t.Run("red bold text", func(t *testing.T) {
 		res := Render{Red, Bold}.Sprintf("I am Red & Bold!")
-		xt.Eq(t, esc+"31;1mI am Red & Bold!", res)
+		xt.Eq(t, esc+"[31;1mI am Red & Bold!", res)
 	})
 
 	t.Run("bold red text", func(t *testing.T) {
 		res := Render{Bold, Red}.Sprintf("I am Red & Bold!")
-		xt.Eq(t, esc+"1;31mI am Red & Bold!", res)
+		xt.Eq(t, esc+"[1;31mI am Red & Bold!", res)
 	})
 
 	t.Run("underlined bold white on bright cyan background", func(t *testing.T) {
 		txt := "I am underlined bold white on bright cyan!"
 		res := Render{Bold, Yellow, Underline, BgBrightCyan}.Sprintf(txt)
-		xt.Eq(t, esc+"1;33;4;106m"+txt, res)
+		xt.Eq(t, esc+"[1;33;4;106m"+txt, res)
 	})
 
 	t.Run("red on yellow background using 8-bit colors", func(t *testing.T) {
 		txt := "I am red on yellow text! "
 		res := Render{FgColor8(196), BgColor8(226)}.Sprintf(txt)
-		xt.Eq(t, esc+"38;5;196;48;5;226m"+txt, res)
+		xt.Eq(t, esc+"[38;5;196;48;5;226m"+txt, res)
 	})
 
 	t.Run("24-bit (RGB) colors", func(t *testing.T) {
 		txt := "I am RGB pink on cyan text!"
 		res := Render{FgColor24(255, 0, 222), BgColor24(23, 253, 255)}.Sprintf(txt)
-		xt.Eq(t, esc+"38;2;255;0;222;48;2;23;253;255m"+txt, res)
+		xt.Eq(t, esc+"[38;2;255;0;222;48;2;23;253;255m"+txt, res)
 	})
 }

--- a/xterm/spinner.go
+++ b/xterm/spinner.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2021, Geert JM Vanderkelen
+
+package xterm
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/geertjanvdk/xkit/xansi"
+)
+
+var defaultDelay = time.Millisecond * 500
+
+type spinnerSet struct {
+	characters           []string
+	notSpinningCharacter string
+}
+
+var spinnerSets = map[string]spinnerSet{
+	"braille-dots": {
+		characters:           []string{"⣾", "⣷", "⣯", "⣟", "⡿", "⢿", "⣻", "⣽"},
+		notSpinningCharacter: "\u2800", // BRAILLE PATTERN BLANK
+	},
+}
+
+type Spinner struct {
+	spinnerSet    spinnerSet
+	out           io.Writer
+	chanStop      chan struct{}
+	MessageBefore string        // shown before the spinner
+	MessageAfter  string        // shown after the spinner
+	Delay         time.Duration // duration between each spin
+	Render        *xansi.Render
+
+	spinning bool
+	mu       sync.RWMutex
+}
+
+func NewSpinner() (*Spinner, error) {
+	s := &Spinner{
+		spinnerSet: spinnerSets["braille-dots"],
+		out:        os.Stdout,
+		chanStop:   make(chan struct{}),
+		Delay:      defaultDelay,
+	}
+	return s, nil
+}
+
+func (s *Spinner) write(spinChar int, before, after string) {
+	var c string
+	if spinChar == -1 {
+		c = s.spinnerSet.notSpinningCharacter
+	} else {
+		c = s.spinnerSet.characters[spinChar]
+	}
+
+	if s.Render != nil {
+		_, _ = fmt.Fprintf(s.out, "\r%s%s%s%s", before,
+			s.Render.Sprintf("%s", c), xansi.Reset(), after)
+	} else {
+		_, _ = fmt.Fprintf(s.out, "\r%s%s%s", before, c, after)
+	}
+}
+
+func (s *Spinner) Start() {
+	s.mu.Lock()
+	if s.spinning {
+		s.mu.Unlock()
+		return
+	}
+	s.spinning = true
+	_, _ = fmt.Fprintf(s.out, xansi.HideCursor)
+	s.mu.Unlock()
+
+	go func() {
+		for {
+			for i := 0; i < len(s.spinnerSet.characters); i++ {
+				select {
+				case <-s.chanStop:
+					return
+				default:
+					s.mu.Lock()
+					s.clearLine()
+					s.write(i, s.MessageBefore, s.MessageAfter)
+					s.mu.Unlock()
+					time.Sleep(s.Delay)
+				}
+			}
+		}
+	}()
+}
+
+func (s *Spinner) Stop() {
+	s.StopCustom("", "")
+}
+
+func (s *Spinner) StopCustom(before, after string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.spinning {
+		s.spinning = false
+		s.clearLine()
+		if after != "" {
+			if before == "" {
+				before = s.MessageBefore
+			}
+			s.write(-1, before, after)
+		}
+		s.chanStop <- struct{}{}
+	}
+}
+
+func (s *Spinner) clearLine() {
+	_, _ = fmt.Fprintf(s.out, xansi.ClearLineAtCursor)
+}

--- a/xterm/spinner_test.go
+++ b/xterm/spinner_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021, Geert JM Vanderkelen
+
+package xterm
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/geertjanvdk/xkit/xt"
+)
+
+func TestNewSpinner(t *testing.T) {
+	t.Run("3 seconds of work", func(t *testing.T) {
+		var output bytes.Buffer
+		spinner, _ := NewSpinner()
+		spinner.Delay = time.Second
+		spinner.out = &output
+		spinner.MessageBefore = "🍺 "
+		spinner.Start()
+
+		spinner.MessageAfter = " get beer from fridge"
+		time.Sleep(time.Second)
+		spinner.MessageAfter = " enjoy beer"
+		time.Sleep(time.Second * 2)
+
+		// we deal with time; so timing can screw up
+		got := output.Bytes()
+		xt.Assert(t, bytes.Contains(got, []byte{0x20, 0xe2, 0xa3, 0xbe, 0x20}), "expected ⣾")
+		xt.Assert(t, bytes.Contains(got, []byte{0x20, 0xe2, 0xa3, 0xb7, 0x20}), "expected ⣷")
+		xt.Assert(t, bytes.Contains(got, []byte{0x20, 0xe2, 0xa3, 0xaf, 0x20}), "expected ⣯")
+	})
+}


### PR DESCRIPTION
We add functionality to show a spinner, a kind of progress indicator. It
will by default click every 500ms and show the current message.

The current line in the terminal, where the cursor is, will be cleared
and updated, so that the following 3 lines are showing some animation:

    🍺 ⣾ message 1
    🍺 ⣷ message 2
    🍺 ⠀ All done!