### PR TITLE
Add WithError to xlog.Logger

### DIFF
--- a/xlog/entry.go
+++ b/xlog/entry.go
@@ -159,7 +159,9 @@ func (e *Entry) WithScope(scope string) *Entry {
 }
 
 func (e *Entry) WithError(err error) *Entry {
-	e.Fields[FieldError] = err.Error()
+	if err != nil {
+		e.Fields[FieldError] = err.Error()
+	}
 
 	return e
 }

--- a/xlog/log.go
+++ b/xlog/log.go
@@ -56,6 +56,12 @@ func (l *Logger) isLogged(level Level) bool {
 	return l.level >= level
 }
 
+// WithError returns an entry with value of field 'error' set to err.
+// This is the same as calling Logger.WithField(FieldError, err).
+func (l *Logger) WithError(err error) *Entry {
+	return newEntry(l).WithError(err)
+}
+
 func (l *Logger) WithField(name string, value interface{}) *Entry {
 	return newEntry(l).WithField(name, value)
 }

--- a/xlog/logger_test.go
+++ b/xlog/logger_test.go
@@ -54,3 +54,32 @@ func TestLogger_Logf(t *testing.T) {
 		xt.Assert(t, strings.Contains(res, `time=`))
 	})
 }
+
+func TestLogger_WithError(t *testing.T) {
+	t.Run("no error field when err is nil", func(t *testing.T) {
+		out := &bytes.Buffer{}
+
+		l := New()
+		l.Out = out
+
+		l.WithError(nil).Info("no error field")
+
+		exp := `^time=.*?\s{1}level=info msg="no error field"$`
+		got := strings.TrimSpace(out.String())
+		xt.Match(t, exp, got)
+	})
+
+	t.Run("with error field when err is not nil", func(t *testing.T) {
+		out := &bytes.Buffer{}
+
+		l := New()
+		l.Out = out
+
+		l.WithError(fmt.Errorf("this is an error")).Info("no error field")
+
+		exp := `^time=.*?\s{1}level=info msg="no error field" err="this is an error"$`
+		got := strings.TrimSpace(out.String())
+		fmt.Println(got)
+		xt.Match(t, exp, got)
+	})
+}

--- a/xt/regex.go
+++ b/xt/regex.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+// Match tests whether the string s contains any match of the regular
+// expression pattern.
 func Match(t *testing.T, pattern, s string, messages ...string) {
 	TestHelper(t)
 


### PR DESCRIPTION
We add the missing `WithError` method to the `Logger` type.

We also make sure that when `WithError` is used, it only works when
the argument err is not nil.