### PR TITLE
Add package xdoc for generating documentation from Go source

### DIFF
--- a/xdoc/cmd/xgodoc/main.go
+++ b/xdoc/cmd/xgodoc/main.go
@@ -1,0 +1,292 @@
+// Copyright (c) 2021, Geert JM Vanderkelen
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/geertjanvdk/xkit/xansi"
+	"github.com/geertjanvdk/xkit/xdoc"
+	"github.com/geertjanvdk/xkit/xpath"
+)
+
+var (
+	flagPackageDir string
+	flagOut        string
+	flagForceWrite bool
+	flagNoHR       bool
+)
+
+var writeTo io.Writer
+
+func write(a ...interface{}) {
+	_, _ = fmt.Fprint(writeTo, a...)
+}
+
+func writef(format string, a ...interface{}) {
+	_, _ = fmt.Fprintf(writeTo, format, a...)
+}
+
+func writeln(a ...interface{}) {
+	_, _ = fmt.Fprintln(writeTo, a...)
+}
+
+func printErrorf(format string, a ...interface{}) {
+	_, _ = fmt.Fprintf(os.Stderr, xansi.Render{xansi.Red}.Sprintf("Error: "+format+"\n", a...)+xansi.Reset())
+}
+
+func printSuccessf(format string, a ...interface{}) {
+	_, _ = fmt.Fprintf(os.Stderr, xansi.Render{xansi.Blue}.Sprintf(format+"\n", a...)+xansi.Reset())
+}
+
+func printDebugf(format string, a ...interface{}) {
+	_, _ = fmt.Fprintf(os.Stderr, xansi.Render{xansi.BrightBlack}.Sprintf(format+"\n", a...)+xansi.Reset())
+}
+
+var _ = printDebugf // fool linters: function is used
+
+func main() {
+	flag.StringVar(&flagPackageDir, "package-dir", ".",
+		"Path of package to generate docs for (can be relative)")
+	flag.StringVar(&flagOut, "output", "",
+		"File where output is stored; use '-' for STDOUT (default <packageName>.md)")
+	flag.BoolVar(&flagForceWrite, "force", false,
+		"Whether we overwrite existing files or not")
+	flag.BoolVar(&flagNoHR, "no-hr", false,
+		"Whether to show horizontal rules or not")
+
+	flag.Parse()
+
+	doc := xdoc.New(flagPackageDir)
+
+	if flagOut == "" {
+		flagOut = doc.PackageName + ".md"
+	}
+
+	if flagOut != "-" {
+		if !path.IsAbs(flagOut) {
+			wd, err := os.Getwd()
+			if err != nil {
+				printErrorf("failed getting current working directory (%s)", err)
+				os.Exit(1)
+			}
+			flagOut = path.Join(wd, flagOut)
+		}
+
+		if !flagForceWrite && xpath.IsRegularFile(flagOut) {
+			printErrorf("file %s exists (use -force to overwrite)", flagOut)
+			os.Exit(1)
+		}
+
+		var err error
+		writeTo, err = os.OpenFile(flagOut, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0666)
+		if err != nil {
+			printErrorf("output file cannot be used (%s)", err)
+			os.Exit(1)
+		}
+		defer func() {
+			if err := writeTo.(io.Closer).Close(); err != nil {
+				printErrorf("output file cannot be closed (%s)", err)
+				os.Exit(1)
+			}
+		}()
+		printSuccessf("Writing to file %s", flagOut)
+	} else {
+		writeTo = os.Stdout
+	}
+
+	mdTitlef(1, "Package %s", doc.PackageName)
+
+	mdTitle(2, "Overview")
+
+	write(strings.TrimSpace(doc.PackageDoc) + "\n")
+
+	mdHorizontalRule()
+
+	/*
+	 * Index
+	 */
+
+	mdTitle(2, "Index")
+
+	if len(doc.Constants) > 0 {
+		n := "Constants"
+		writef("* [%s](#%s)\n", n, gitHubHeaderID(n))
+	}
+
+	if len(doc.Variables) > 0 {
+		n := "Variables"
+		writef("* [%s](#%s)\n", n, gitHubHeaderID(n))
+	}
+
+	if len(doc.Functions) > 0 {
+		for _, pf := range doc.Functions.SortedKeys() {
+			f := doc.Functions[pf]
+			writef("* [func %s](#%s)\n", doc.Functions[pf].Signature(), gitHubHeaderID("func "+f.Signature()))
+		}
+	}
+
+	if len(doc.Structs) > 0 {
+		for _, t := range doc.Structs.SortedKeys() {
+			c := doc.Structs[t]
+			writef("* [type %s](#%s)\n", c.Name, gitHubHeaderID(c.Name))
+			for _, sf := range c.Constructors.SortedKeys() {
+				f := c.Constructors[sf]
+				writef("  - [func %s](#%s)\n", f.Signature(), gitHubHeaderID("func "+f.Signature()))
+			}
+			for _, sf := range c.Methods.SortedKeys() {
+				f := c.Methods[sf]
+				writef("  - [func %s](#%s)\n", f.Signature(), gitHubHeaderID("func "+f.Signature()))
+			}
+		}
+		writeln()
+	}
+
+	/*
+	 * Content
+	 */
+
+	if len(doc.Constants) > 0 {
+		mdHorizontalRule()
+		mdTitle(2, "Constants")
+
+		for _, f := range doc.Constants.SortedKeys() {
+			mdTitlef(3, "const %s", doc.Constants[f].Name)
+			writef("    %s\n\n", doc.Constants[f].Signature())
+			if doc.Constants[f].Doc != "" {
+				writef("%s\n\n", doc.Constants[f].Doc)
+			}
+		}
+	}
+
+	if len(doc.Variables) > 0 {
+		mdHorizontalRule()
+		mdTitle(2, "Variables")
+
+		for _, f := range doc.Variables.SortedKeys() {
+			mdTitlef(3, "var %s", doc.Variables[f].Name)
+			writef("    %s\n\n", doc.Variables[f].Signature())
+			if doc.Variables[f].Doc != "" {
+				writef("%s\n\n", doc.Variables[f].Doc)
+			}
+		}
+	}
+
+	if len(doc.Functions) > 0 {
+		mdHorizontalRule()
+		mdTitle(2, "Functions")
+
+		for _, df := range doc.Functions.SortedKeys() {
+			f := doc.Functions[df]
+			mdTitlef(3, "func %s",
+				f.Signature(),
+			)
+			writef("    %s\n\n", f.Signature())
+			if f.Doc != "" {
+				writef("%s\n\n", f.Doc)
+			}
+		}
+	}
+
+	if len(doc.Structs) > 0 {
+		mdHorizontalRule()
+		mdTitle(2, "Types")
+
+		for _, t := range doc.Structs.SortedKeys() {
+			c := doc.Structs[t]
+			mdTitlef(3, "type %s", c.Name)
+
+			writef("    type %s struct {\n", c.Name)
+			for _, f := range c.Fields {
+				writef("         %s\n", f)
+			}
+			writef("    }\n")
+
+			if c.Doc != "" {
+				writef("%s\n\n", c.Doc)
+			}
+			for _, pf := range c.Constructors.SortedKeys() {
+				f := c.Constructors[pf]
+				mdTitlef(4, "func %s",
+					f.Signature(),
+				)
+				writef("    %s\n\n", f.Signature())
+				if f.Doc != "" {
+					writef("%s\n\n", f.Doc)
+				}
+			}
+			for _, pf := range c.Methods.SortedKeys() {
+				f := c.Methods[pf]
+				mdTitlef(4, "func %s",
+					f.Signature(),
+				)
+				writef("    %s\n\n", f.Signature())
+				if f.Doc != "" {
+					writef("%s\n\n", f.Doc)
+				}
+			}
+		}
+	}
+
+	printSuccessf("Successfully written to %s", flagOut)
+}
+
+func mdTitle(level int, title string) {
+	if level < 1 || level > 6 {
+		panic("level between 1 and 6")
+	}
+
+	switch level {
+	case 1:
+		writef("%s\n%s\n\n", title, strings.Repeat("=", len(title)))
+	case 2:
+		writef("%s\n%s\n\n", title, strings.Repeat("-", len(title)))
+	default:
+		writef("%s %s\n\n", strings.Repeat("#", level), title)
+	}
+}
+
+func mdTitlef(level int, title string, a ...interface{}) {
+	mdTitle(level, fmt.Sprintf(title, a...))
+}
+
+func mdHorizontalRule() {
+	if flagNoHR {
+		writeln()
+		return
+	}
+	writeln("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -")
+}
+
+var reGitHubHeaderBanned = regexp.MustCompile(`[^\P{P}-]`)
+var reGitHubUpperEncoded = regexp.MustCompile(`%%{[a-f0-9]{2}`)
+var reWhiteSpaces = regexp.MustCompile(`\s+`)
+
+var headerIndex = make(map[string]int)
+
+func gitHubHeaderID(h string) string {
+	result := h
+
+	result = reWhiteSpaces.ReplaceAllString(result, "-")
+	result = reGitHubHeaderBanned.ReplaceAllString(result, "")
+	result = strings.ToLower(result)
+
+	result = url.PathEscape(result)
+	result = reGitHubUpperEncoded.ReplaceAllStringFunc(result, strings.ToUpper)
+
+	if _, have := headerIndex[result]; have {
+		headerIndex[result]++
+		result = fmt.Sprintf("%s-%d", result, headerIndex[result])
+	} else {
+		headerIndex[result] = 0
+	}
+
+	return result
+}

--- a/xdoc/cmd/xgodoc/xgodoc_test.go
+++ b/xdoc/cmd/xgodoc/xgodoc_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021, Geert JM Vanderkelen
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/geertjanvdk/xkit/xt"
+)
+
+func TestGitHubHeaderID(t *testing.T) {
+	cases := []struct {
+		have string
+		exp  string
+	}{
+		{have: "café", exp: "caf%C3%A9"},
+		{have: "Löffel", exp: "l%C3%B6ffel"},
+		{have: "func (c *Client) SetAuthzBearer(s string)",
+			exp: "func-c-client-setauthzbearers-string"},
+		{have: "func (c *Client) SetAuthzBearer(s string)", // 2nd pass adds -1 suffix
+			exp: "func-c-client-setauthzbearers-string-1"},
+		{have: "func (c *Client) SetAuthzBearer(s string)", // 3nd pass adds -2 suffix
+			exp: "func-c-client-setauthzbearers-string-2"},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%02d#%s", i, c.have), func(t *testing.T) {
+			xt.Eq(t, c.exp, gitHubHeaderID(c.have))
+		})
+	}
+
+}

--- a/xdoc/godoc.go
+++ b/xdoc/godoc.go
@@ -1,0 +1,285 @@
+// Copyright (c) 2021, Geert JM Vanderkelen
+
+package xdoc
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/geertjanvdk/xkit/xlog"
+)
+
+type DocInfo struct {
+	PackageDoc  string
+	PackageName string
+	Constants   Values
+	Variables   Values
+	Functions   Functions
+	Structs     Structs
+}
+
+func isExported(name string) bool {
+	c, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(c)
+}
+
+func New(toDoc string) *DocInfo {
+	fileSet := token.NewFileSet()
+
+	dir, err := parser.ParseDir(fileSet, toDoc, nil, parser.ParseComments)
+	if err != nil {
+		xlog.Error(err)
+	}
+
+	docInfo := &DocInfo{
+		Constants: make(Values),
+		Variables: make(Values),
+		Functions: make(Functions),
+		Structs:   make(Structs),
+	}
+
+	for packageName, a := range dir {
+		if strings.HasSuffix(packageName, "_test") {
+			continue
+		}
+		docInfo.PackageName = packageName
+
+		// first pass: get all struct types, constants, and variables
+		for filename, file := range a.Files {
+			if strings.HasSuffix(filename, "_test.go") {
+				continue
+			}
+
+			if strings.Contains(filename, path.Join(docInfo.PackageName, "doc.go")) && file.Doc != nil {
+				docInfo.PackageDoc = file.Doc.Text()
+			}
+
+			for _, decl := range file.Decls {
+				d, ok := decl.(*ast.GenDecl)
+				if !ok {
+					continue
+				}
+
+				var doc string
+				if d.Doc != nil {
+					doc = d.Doc.Text()
+				}
+
+				switch d.Tok.String() {
+				case "type":
+					for _, spec := range d.Specs {
+						switch s := spec.(type) {
+						case *ast.TypeSpec:
+							if !isExported(s.Name.String()) {
+								continue
+							}
+
+							st, ok := s.Type.(*ast.StructType)
+							if !ok {
+								continue
+							}
+
+							n := newStruct(s.Name.String())
+
+							if st.Fields != nil {
+								for _, f := range st.Fields.List {
+									if len(f.Names) == 0 {
+										// embedded
+										n.Fields = append(n.Fields, whatIsExpr(f.Type))
+										continue
+									}
+
+									n.Fields = append(n.Fields, fmt.Sprintf("%s %s %s",
+										f.Names[0],
+										whatIsExpr(f.Type),
+										whatIsExpr(f.Tag),
+									))
+								}
+							}
+
+							n.Doc = doc
+							docInfo.Structs[packageName+"."+s.Name.String()] = n
+						}
+					}
+				case "const", "var":
+					for _, spec := range d.Specs {
+						switch s := spec.(type) {
+						case *ast.ValueSpec:
+							if !isExported(s.Names[0].Name) {
+								continue
+							}
+							c := newValue(s.Names[0].String(), whatIsExpr(s.Values[0]))
+							c.IsConstant = d.Tok.String() == "const"
+							c.Doc = doc
+							if c.IsConstant {
+								docInfo.Constants[packageName+"."+c.Name] = c
+							} else {
+								docInfo.Variables[packageName+"."+c.Name] = c
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// second pass: get functions and method; separating Constructors
+		for filename, file := range a.Files {
+			if strings.HasSuffix(filename, "_test.go") {
+				continue
+			}
+
+			if filename == path.Join(packageName, "doc.go") && file.Doc != nil {
+				docInfo.PackageDoc = ""
+				for _, d := range file.Doc.List {
+					txt := strings.TrimSpace(d.Text)
+					txt = strings.Replace(txt, "/*", "", 1)
+					txt = strings.Replace(txt, "*/", "", 1)
+					txt = strings.TrimSpace(txt)
+					docInfo.PackageDoc += txt
+				}
+			}
+
+			for _, decl := range file.Decls {
+				var registered bool
+
+				d, ok := decl.(*ast.FuncDecl)
+				if !ok {
+					continue
+				}
+
+				if !d.Name.IsExported() {
+					continue
+				}
+
+				var doc string
+				if d.Doc != nil {
+					doc = d.Doc.Text()
+				}
+
+				if d.Recv != nil {
+					// this is a method (function which has a receiver)
+					n := strings.TrimPrefix(whatIsExpr(d.Recv.List[0].Type), "*")
+					if !isExported(n) {
+						continue
+					}
+					if t, have := docInfo.Structs[packageName+"."+n]; have {
+						t.Methods[d.Name.String()] = &Function{
+							Name:  d.Name.String(),
+							type_: d.Type,
+							recv:  d.Recv,
+							Doc:   doc,
+						}
+						registered = true
+					}
+				} else {
+					// check if this function is a constructor, or it returns a struct define in package
+					if d.Type.Results != nil {
+						for _, r := range d.Type.Results.List {
+							n := packageName + "." + strings.TrimPrefix(whatIsExpr(r.Type), "*")
+							if t, have := docInfo.Structs[n]; have {
+								t.Constructors[d.Name.String()] = &Function{
+									Name:  d.Name.String(),
+									type_: d.Type,
+									recv:  d.Recv,
+									Doc:   doc,
+								}
+								registered = true
+								break
+							}
+						}
+					}
+
+					// non-constructor function
+					if !registered {
+						docInfo.Functions[packageName+"."+d.Name.String()] = &Function{
+							Name:  d.Name.String(),
+							type_: d.Type,
+							recv:  d.Recv,
+							Doc:   doc,
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return docInfo
+}
+
+func whatIsExpr(x ast.Expr) string {
+	if x == nil {
+		return ""
+	}
+	switch n := x.(type) {
+	case *ast.ArrayType:
+		return "[]" + whatIsExpr(n.Elt)
+	case *ast.Ellipsis:
+		return "..." + whatIsExpr(n.Elt)
+	case *ast.Ident:
+		if ast.IsExported(n.Name) {
+			return n.Name
+		}
+		return n.Name
+	case *ast.InterfaceType:
+		return "interface{}"
+	case *ast.SelectorExpr:
+		return whatIsExpr(n.X) + "." + n.Sel.String()
+	case *ast.StarExpr:
+		return "*" + whatIsExpr(n.X)
+	case *ast.FuncType:
+		return "func" + funcSignature("", n, nil)
+	case *ast.BasicLit:
+		if n == nil {
+			return ""
+		}
+		return n.Value
+	default:
+		return fmt.Sprintf("%T", x)
+	}
+}
+
+func argumentList(fields *ast.FieldList) []string {
+	if fields == nil || fields.List == nil {
+		return nil
+	}
+
+	params := make([]string, len(fields.List))
+	for i, p := range fields.List {
+		expr := whatIsExpr(p.Type)
+		if p.Names != nil {
+			params[i] = p.Names[0].Name + " " + expr
+		} else {
+			params[i] = expr
+		}
+	}
+
+	return params
+}
+
+func funcSignature(fnName string, ft *ast.FuncType, recv *ast.FieldList) string {
+	params := argumentList(ft.Params)
+	results := argumentList(ft.Results)
+
+	var result string
+	switch len(results) {
+	case 0:
+		result = ""
+	case 1:
+		result = " " + results[0]
+	default:
+		result = " (" + strings.Join(results, ", ") + ")"
+	}
+
+	var receiver string
+	if recv != nil {
+		receiver = "(" + argumentList(recv)[0] + ") "
+	}
+
+	return fmt.Sprintf("%s%s(%s)%s", receiver, fnName, strings.Join(params, ", "), result)
+}

--- a/xdoc/types.go
+++ b/xdoc/types.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2021, Geert JM Vanderkelen
+
+package xdoc
+
+import (
+	"fmt"
+	"go/ast"
+	"sort"
+	"strings"
+)
+
+type Functions map[string]*Function
+
+func (m Functions) SortedKeys() []string {
+	keys := make([]string, len(m))
+	var i int
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+type Structs map[string]*Struct
+
+func (m Structs) SortedKeys() []string {
+	keys := make([]string, len(m))
+	var i int
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+type Struct struct {
+	Name         string
+	Constructors Functions
+	Methods      Functions
+	Fields       []string
+	Doc          string
+}
+
+func newStruct(name string) *Struct {
+	return &Struct{
+		Name:         name,
+		Constructors: make(Functions),
+		Methods:      make(Functions),
+	}
+}
+
+type Function struct {
+	Name string
+	Doc  string
+
+	type_ *ast.FuncType
+	recv  *ast.FieldList
+}
+
+func (sf Function) Signature() string {
+	params := argumentList(sf.type_.Params)
+	results := argumentList(sf.type_.Results)
+
+	var result string
+	switch len(results) {
+	case 0:
+		result = ""
+	case 1:
+		result = " " + results[0]
+	default:
+		result = " (" + strings.Join(results, ", ") + ")"
+	}
+
+	var receiver string
+	if sf.recv != nil {
+		receiver = "(" + argumentList(sf.recv)[0] + ") "
+	}
+
+	return fmt.Sprintf("%s%s(%s)%s", receiver, sf.Name, strings.Join(params, ", "), result)
+}
+
+type Value struct {
+	Name       string
+	Value      string
+	IsConstant bool
+	Doc        string
+}
+
+func (sv Value) Signature() string {
+	t := "var"
+	if sv.IsConstant {
+		t = "const"
+	}
+
+	return fmt.Sprintf("%s %s = %s", t, sv.Name, sv.Value)
+}
+
+type Values map[string]*Value
+
+func (m Values) SortedKeys() []string {
+	keys := make([]string, len(m))
+	var i int
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func newValue(name, value string) *Value {
+	return &Value{
+		Name:       name,
+		Value:      value,
+		IsConstant: false,
+	}
+}

--- a/xhttp/doc.go
+++ b/xhttp/doc.go
@@ -1,11 +1,9 @@
 // Copyright (c) 2020, Geert JM Vanderkelen
 
-package xhttp
-
 /*
 Package xhttp contains tools and helper functions around the Go http package.
 
-HTTP Client
+### HTTP Client
 
 Creating a HTTP client is done using the `NewClient` function. It takes functional
 options so that it is easier to configure.
@@ -25,3 +23,4 @@ The following functional options are available:
 - WithBearer(string)
 
 */
+package xhttp

--- a/xt/assert.go
+++ b/xt/assert.go
@@ -4,6 +4,8 @@ package xt
 
 import "testing"
 
+// Assert tests if condition is true. When not, messages are displayed.
+// This is equivalent as Eq(t, true, condition, messages...).
 func Assert(t *testing.T, condition bool, messages ...string) {
 	TestHelper(t)
 

--- a/xt/doc.go
+++ b/xt/doc.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2021, Geert JM Vanderkelen
+
+/*
+Package xt offers a number of functions to make testing more comfortable.
+
+The following functions are available:
+
+* Eq(t *testing.T, expect, have interface{}, messages ...string)
+* Assert(t *testing.T, condition bool, messages ...string)
+* Panics(t *testing.T, f func())
+* Match(t *testing.T, pattern, s string, messages ...string)
+
+The above is already plenty as Eq and Panics would suffice.
+
+*/
+package xt


### PR DESCRIPTION
We add a new package xdoc which contains APIs and a command line
interface (CLI) for generating documentation, mimicking pkg.go.dev.
The intention is to have something that used to generate documentation
for private/commercial projects. Functionality like a server serving
the docs (like `go doc`) is not available, but the intention is that
using `xdoc` the user can herself implement this.

Though not complete, it is already functional. Some parts are still
missing like types created from other types (such as `type Foo string`).

The index generate is optimized for GitHub, but the header links might
work on other platforms and IDEs.

The CLI can be used as follows:

    go run github.com/geertjanvdk/xkit/xdoc/cmd/xgodoc \
        --package-dir path/to/your/pkg -output pkg_doc.md