### PR TITLE
Change how log level is set in xlog

### DIFF
--- a/xlog/defaults.go
+++ b/xlog/defaults.go
@@ -4,13 +4,47 @@ package xlog
 
 import "os"
 
-// defaultLogLevel defines the default log level.
-var defaultLogLevel = ErrorLevel
+type Level int
+
+// A classic way of describing the logging level. Note that 'Panic' is the
+// Go-way for 'Trace'.
+const (
+	FatalLevel   Level = -1 // exits
+	DefaultLevel Level = 0  // use whatever is xlog's default
+	ErrorLevel   Level = 1
+	WarnLevel    Level = 2
+	InfoLevel    Level = 3
+	DebugLevel   Level = 4
+	PanicLevel   Level = 5
+)
+
+const (
+	lowestLevel  = FatalLevel
+	highestLevel = PanicLevel
+)
+
+var levelName = map[Level]string{
+	FatalLevel: "fatal",
+	PanicLevel: "panic",
+	ErrorLevel: "error",
+	WarnLevel:  "warn",
+	InfoLevel:  "info",
+	DebugLevel: "debug",
+}
+
+var defaultActiveLevels = activeLevels{
+	FatalLevel: true,
+	ErrorLevel: true,
+	WarnLevel:  true,
+	InfoLevel:  true,
+	DebugLevel: false,
+	PanicLevel: false,
+}
 
 // defaultLogger is always available when using xlog.
 var defaultLogger = &Logger{
-	level:     defaultLogLevel,
-	Formatter: &TextFormat{},
-	Out:       os.Stderr,
-	UseUTC:    true,
+	Formatter:    &TextFormat{},
+	Out:          os.Stderr,
+	UseUTC:       true,
+	activeLevels: newActiveLevels(),
 }

--- a/xlog/doc.go
+++ b/xlog/doc.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2021, Geert JM Vanderkelen
+
+/*
+Package xlog implements a sofisticated logging package.
+
+### Quick Start
+
+When importing xlog, logging is can be used right away:
+
+	package main
+
+	import "github.com/geertjanvdk/xkit/xlog"
+
+	func main() {
+		xlog.Info("I am an informational.")
+	}
+
+It is possible to add fields as well as error or a scope:
+
+	package main
+
+	import "github.com/geertjanvdk/xkit/xlog"
+
+	func main() {
+		if err := createUser(user); err != nil {
+			xlog.WithError(err).Errorf("creating user for %s", appName)
+		} else {
+			xlog.WithScope("users").WithField("user", user.ID).Infof("user created")
+		}
+	}
+
+
+### Setting Logging Levels
+
+xlog does not support the classic way of setting the level of logging. Normally,
+when you set log level WARN, nothing informational is written, and only errors
+are reported.
+
+In xlog levels are activated, so that the application can choose which are
+logged in a dynamic manner.
+
+For example: an application is running and has the defaults set. This means that
+informational, warning, and error messages are logged, as well as fatal or
+terminating events. When, however, the developers need for a shor time to have
+debugging enabled (for example in staging environments), they can do so by
+activating the debug level.
+
+	xlog.ActivateLevel(xlog.DebugLevel)
+
+How this is dynamically done is up to the application. It could be possible to
+have a process signal, an API call, or as simple as creating a file in a
+specific folder.
+
+Deactivating is simply done using using the Deactivate method:
+
+	xlog.DeactivateLevel(xlog.DebugLevel)
+
+
+### Custom Loggers
+
+xlog comes with a logger. It is however more practical for applications to
+instantiate their own, and customize it.
+
+	package main
+
+	import "github.com/geertjanvdk/xkit/xlog"
+
+	func main() {
+		logger := xlog.New()
+		logger.DeactivateLevels(xlog.WarnLevel, xlog.InfoLevel)
+		logger.Scope = "my-app"
+		logger.Errorf("only errors are logged (and fatal events)")
+	}
+
+*/
+package xlog

--- a/xlog/xlog.go
+++ b/xlog/xlog.go
@@ -6,33 +6,30 @@ import (
 	"io"
 )
 
-type Level int
-
-const (
-	FatalLevel Level = -1 // exits
-	PanicLevel Level = 1
-	ErrorLevel Level = 2
-	WarnLevel  Level = 3
-	InfoLevel  Level = 4
-	DebugLevel Level = 5
-)
-
-var levelName = map[Level]string{
-	PanicLevel: "panic",
-	ErrorLevel: "error",
-	WarnLevel:  "warn",
-	InfoLevel:  "info",
-	DebugLevel: "debug",
+// ActivateLevels is used to activate particular levels of the default logger.
+// For example, ActivateLevels(DebugLevel) can be used  if
+// the logger logs errors, but debug message are wanted, without
+// info messages.
+func ActivateLevels(levels ...Level) {
+	defaultLogger.ActivateLevels(levels...)
 }
 
-// SetLevel sets the level of the default logger.
-func SetLevel(level Level) {
-	defaultLogger.SetLevel(level)
+// DeactivateLevels is used to deactivate particular levels of the default logger.
+// For example, DeactivateLevels(DebugLevel) can be used to deactivate all
+// debugging messages.
+func DeactivateLevels(levels ...Level) {
+	defaultLogger.DeactivateLevels(levels...)
 }
 
-// GetLevel returns the level of the default logger.
-func GetLevel() Level {
-	return defaultLogger.Level()
+// Levels returns the active levels.
+func Levels() []Level {
+	return defaultLogger.Levels()
+}
+
+// LevelsAsStrings returns the active levels their names. The result
+// is sorted.
+func LevelsAsStrings() []string {
+	return defaultLogger.LevelsAsStrings()
 }
 
 // SetOut sets where the output of the default logger goes to.

--- a/xlog/xlog_test.go
+++ b/xlog/xlog_test.go
@@ -12,16 +12,6 @@ import (
 	"github.com/geertjanvdk/xkit/xt"
 )
 
-func TestSetGetLevel(t *testing.T) {
-	defer func() { defaultLogger.level = defaultLogLevel }()
-
-	xt.Eq(t, defaultLogLevel, defaultLogger.level)
-	SetLevel(DebugLevel)
-	xt.Eq(t, DebugLevel, GetLevel())
-	SetLevel(defaultLogLevel)
-	xt.Eq(t, defaultLogLevel, defaultLogger.level)
-}
-
 func TestSetGetOut(t *testing.T) {
 	defer func() { defaultLogger.Out = os.Stderr }()
 	out := &bytes.Buffer{}
@@ -126,7 +116,7 @@ func TestPanic(t *testing.T) {
 	t.Run("panics are not logged; but panic anyway", func(t *testing.T) {
 		defer func() {
 			defaultLogger.Out = os.Stderr
-			defaultLogger.SetLevel(defaultLogLevel)
+			defaultLogger.activeLevels = defaultActiveLevels
 		}()
 
 		out := &bytes.Buffer{}
@@ -141,9 +131,9 @@ func TestPanic(t *testing.T) {
 	t.Run("panics are logged when asked", func(t *testing.T) {
 		defer func() {
 			defaultLogger.Out = os.Stderr
-			defaultLogger.SetLevel(defaultLogLevel)
+			defaultLogger.activeLevels = defaultActiveLevels
 		}()
-		defaultLogger.SetLevel(PanicLevel)
+		defaultLogger.ActivateLevels(PanicLevel)
 
 		out := &bytes.Buffer{}
 		SetOut(out)
@@ -160,8 +150,9 @@ func TestPanicf(t *testing.T) {
 	t.Run("panics are not logged; but panic anyway", func(t *testing.T) {
 		defer func() {
 			defaultLogger.Out = os.Stderr
-			defaultLogger.SetLevel(defaultLogLevel)
+			defaultLogger.activeLevels = defaultActiveLevels
 		}()
+		DeactivateLevels(PanicLevel) // default, but make sure
 
 		out := &bytes.Buffer{}
 		SetOut(out)
@@ -175,9 +166,9 @@ func TestPanicf(t *testing.T) {
 	t.Run("panics are logged when asked", func(t *testing.T) {
 		defer func() {
 			defaultLogger.Out = os.Stderr
-			defaultLogger.SetLevel(defaultLogLevel)
+			defaultLogger.activeLevels = defaultActiveLevels
 		}()
-		defaultLogger.SetLevel(PanicLevel)
+		ActivateLevels(PanicLevel)
 
 		out := &bytes.Buffer{}
 		SetOut(out)
@@ -258,9 +249,13 @@ func TestWarnf(t *testing.T) {
 }
 
 func TestDebug(t *testing.T) {
-	defer func() { defaultLogger.Out = os.Stderr }()
+	defer func() {
+		defaultLogger.Out = os.Stderr
+		defaultLogger.activeLevels = defaultActiveLevels
+	}()
 	out := &bytes.Buffer{}
 	SetOut(out)
+	ActivateLevels(DebugLevel)
 
 	Debug("I am debug")
 	expNeedles := []string{
@@ -275,9 +270,13 @@ func TestDebug(t *testing.T) {
 }
 
 func TestDebugf(t *testing.T) {
-	defer func() { defaultLogger.Out = os.Stderr }()
+	defer func() {
+		defaultLogger.Out = os.Stderr
+		defaultLogger.activeLevels = defaultActiveLevels
+	}()
 	out := &bytes.Buffer{}
 	SetOut(out)
+	ActivateLevels(DebugLevel)
 
 	Debugf("I am %s", "debug")
 	expNeedles := []string{


### PR DESCRIPTION
Warning: backwards incompatible, but OK (active development)

Previously, log level was set using the SetLevel function or method.
This did not allow to dynamically enable one or more levels, without
possibly enabling or disabling others.

We change how levels are set by 'activating' them by one. We do not
support any longer the classic "if Info, log everything, if Error
suppress Warn, Info, Debug". Instead, application can set exactly what
they need, at any time, allowing to also set it dynamically.

For example, we can activate and deactivate debugging level at will,
without affecting any other level:

    xlog.ActivateLevels(xlog.DebugLevel)
    // ..
    xlog.DeactivateLevels(xlog.DebugLevel)

By default, loggers have levels Info, Warn, Error, and Fatal activated.

It is possible to retrieve levels that

Applications using the `SetLevel` functionality must change to use
the above shown functions. It is possible to get levels that are
active using `Levels()` and `LevelsAsStrings()` functions and methods.