### PR TITLE
Add xutil.Retry to retry a certain action

### DIFF
--- a/xutil/utility.go
+++ b/xutil/utility.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+package xutil
+
+import "time"
+
+// Retry will rerun action until it does not return an error any longer. It
+// attempts a number of times, with an interval. When unsuccessful, the last
+// error produced by action will be returned.
+// Panics when attempts is less than 1, or interval is negative.
+func Retry(attempts int, interval time.Duration, action func() error) error {
+	if attempts < 1 {
+		panic("attempts must be 1 or greater")
+	}
+
+	if interval < 0 {
+		panic("interval must not be negative")
+	}
+
+	var err error
+	for i := 0; i < attempts; i++ {
+		if err = action(); err == nil {
+			// all good
+			return nil
+		}
+		time.Sleep(interval)
+	}
+
+	return err
+}

--- a/xutil/utility_test.go
+++ b/xutil/utility_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+package xutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/geertjanvdk/xkit/xt"
+)
+
+func TestRetry(t *testing.T) {
+	t.Run("retry 3 times", func(t *testing.T) {
+		counter := 3
+		attempts := counter
+		action := func() error {
+			counter -= 1
+			if counter == 0 {
+				return nil
+			}
+			return fmt.Errorf("not yet")
+		}
+
+		xt.OK(t, Retry(attempts, time.Second/2, action))
+	})
+
+	t.Run("fail after retry 3 times", func(t *testing.T) {
+		counter := 3
+		attempts := counter
+		exp := fmt.Errorf("fail anyway")
+
+		action := func() error {
+			counter -= 1
+			if counter == 0 {
+				return exp
+			}
+			return fmt.Errorf("not yet")
+		}
+
+		err := Retry(attempts, time.Second/2, action)
+		xt.KO(t, err)
+		xt.Eq(t, exp, err)
+	})
+
+	t.Run("panics when attempts < 1", func(t *testing.T) {
+		xt.Panics(t, func() {
+			_ = Retry(0, time.Second/2, func() error { return nil })
+		})
+	})
+
+	t.Run("panics when interval is negative", func(t *testing.T) {
+		xt.Panics(t, func() {
+			_ = Retry(1, -1, func() error { return nil })
+		})
+	})
+}


### PR DESCRIPTION
We add the `Retry` utility which retries to execute an action (function)
a number of times with an optional interval. When the action returns
no error, retrying was successful.